### PR TITLE
AOKP support for n7000 (2/2)

### DIFF
--- a/overlay/n7000/packages/apps/ROMControl/res/values/arrays.xml
+++ b/overlay/n7000/packages/apps/ROMControl/res/values/arrays.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string-array name="available_toggles_entries" translatable="false">
+    <item>USER</item>
+    <item>FAVCONTACT</item>
+    <item>BRIGHTNESS</item>
+    <item>SETTINGS</item>
+    <item>WIFI</item>
+    <item>SIGNAL</item>
+    <item>ROTATE</item>
+    <item>CLOCK</item>
+    <item>GPS</item>
+    <item>IME</item>
+    <item>BATTERY</item>
+    <item>AIRPLANE_MODE</item>
+    <item>BLUETOOTH</item>
+    <item>SWAGGER</item>
+    <item>VIBRATE</item>
+    <item>SILENT</item>
+    <item>SOUNDSTATE</item>
+    <item>SYNC</item>
+    <item>WIFITETHER</item>
+    <item>USBTETHER</item>
+    <item>TORCH</item>
+    <item>2G</item>
+    <item>NAVBARHIDE</item>
+    <item>QUICKRECORD</item>
+  </string-array>
+
+  <string-array name="available_toggles_values" translatable="false">
+    <item>@string/toggle_user</item>
+    <item>@string/toggle_favorite_contact</item>
+    <item>@string/toggle_brightness</item>
+    <item>@string/toggle_settings</item>
+    <item>@string/toggle_wifi</item>
+    <item>@string/toggle_signal</item>
+    <item>@string/toggle_auto_rotate</item>
+    <item>@string/toggle_clock</item>
+    <item>@string/toggle_gps</item>
+    <item>@string/toggle_ime</item>
+    <item>@string/toggle_battery</item>
+    <item>@string/toggle_airplane_mode</item>
+    <item>@string/toggle_bluetooth</item>
+    <item>@string/toggle_swagger</item>
+    <item>@string/toggle_vibrate</item>
+    <item>@string/toggle_silent</item>
+    <item>@string/toggle_sound_state</item>
+    <item>@string/toggle_sync</item>
+    <item>@string/toggle_wifi_tether</item>
+    <item>@string/toggle_usb_tether</item>
+    <item>@string/toggle_torch</item>
+    <item>@string/toggle_2g</item>
+    <item>@string/toggle_navbar_hide</item>
+    <item>@string/toggle_quickrecord</item>
+  </string-array>
+
+  <string-array name="navigation_bar_qty_entries">
+    <item>1</item>
+    <item>2</item>
+    <item>3</item>
+    <item>4</item>
+    <item>5</item>
+    <item>6</item>
+    <item>7</item>
+  </string-array>
+
+  <string-array name="navigation_bar_qty_values" translatable="false">
+    <item>1</item>
+    <item>2</item>
+    <item>3</item>
+    <item>4</item>
+    <item>5</item>
+    <item>6</item>
+    <item>7</item>
+  </string-array>
+
+</resources>

--- a/overlay/n7000/packages/apps/ROMControl/res/values/config.xml
+++ b/overlay/n7000/packages/apps/ROMControl/res/values/config.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Whether or not to display the notification LED settings -->
+    <bool name="has_notification_led">false</bool>
+
+    <!-- Whether device has camera flash or torch capabilities -->
+    <bool name="has_torch">true</bool>
+
+    <!-- Whether device has hardware buttons -->
+    <bool name="has_hardware_buttons">true</bool>
+
+    <!-- Whether can use fast chage -->
+    <bool name="has_fast_charge">false</bool>
+
+    <!-- Whether can use color tuning -->
+    <bool name="has_color_tuning">false</bool>
+</resources>

--- a/products/AndroidProducts.mk
+++ b/products/AndroidProducts.mk
@@ -25,6 +25,7 @@ PRODUCT_MAKEFILES := \
     $(LOCAL_DIR)/manta.mk \
     $(LOCAL_DIR)/maserati.mk \
     $(LOCAL_DIR)/mint.mk \
+    $(LOCAL_DIR)/n7000.mk \
     $(LOCAL_DIR)/odin.mk \
     $(LOCAL_DIR)/p930.mk \
     $(LOCAL_DIR)/solana.mk \

--- a/products/n7000.mk
+++ b/products/n7000.mk
@@ -1,4 +1,4 @@
-# Inherit AOSP device configuration for galaxys2.
+# Inherit AOSP device configuration
 $(call inherit-product, device/samsung/n7000/full_n7000.mk)
 
 # Inherit common product files.

--- a/products/n7000.mk
+++ b/products/n7000.mk
@@ -1,0 +1,29 @@
+# Inherit AOSP device configuration for galaxys2.
+$(call inherit-product, device/samsung/n7000/full_n7000.mk)
+
+# Inherit common product files.
+$(call inherit-product, vendor/aokp/configs/common.mk)
+
+# Inherit GSM common stuff
+$(call inherit-product, vendor/aokp/configs/gsm.mk)
+
+# N7000 overlay
+PRODUCT_PACKAGE_OVERLAYS += vendor/aokp/overlay/n7000
+
+# Setup device specific product configuration.
+PRODUCT_DEVICE := n7000
+PRODUCT_NAME := aokp_n7000
+PRODUCT_BRAND := Samsung
+PRODUCT_MODEL := GT-N7000
+
+# Set build fingerprint / ID / Product Name ect.
+PRODUCT_BUILD_PROP_OVERRIDES += PRODUCT_NAME=GT-N7000 TARGET_DEVICE=GT-N7000 BUILD_FINGERPRINT=samsung/GT-N7000/GT-N7000:4.0.3/IML74K/ZCLP6:user/release-keys PRIVATE_BUILD_DESC="GT-N7000-user 4.0.3 IML74K ZCLP6 release-keys"
+PRODUCT_RELEASE_NAME := GT-N7000
+
+# Copy N7000 specific prebuilt files
+PRODUCT_PACKAGES += \
+    Thinkfree
+
+PRODUCT_COPY_FILES += \
+   vendor/aokp/prebuilt/bootanimation/bootanimation_720_1280.zip:system/media/bootanimation-alt.zip
+

--- a/vendorsetup.sh
+++ b/vendorsetup.sh
@@ -26,6 +26,7 @@ add_lunch_combo aokp_m7tmo-userdebug
 add_lunch_combo aokp_m7ul-userdebug
 add_lunch_combo aokp_maserati-userdebug
 add_lunch_combo aokp_mint-userdebug
+add_lunch_combo aokp_n7000-userdebug
 add_lunch_combo aokp_odin-userdebug
 add_lunch_combo aokp_p930-userdebug
 add_lunch_combo aokp_solana-userdebug


### PR DESCRIPTION
Change-Id: I1cddc13fc27528c2949df5f2cdb58ed0ba2f485f

Device tree for n7000 can be found here at 
https://github.com/ToxicThunder/device_samsung_n7000
